### PR TITLE
fix(SDialog): destory copmonent when closed

### DIFF
--- a/src/components/SDialog.vue
+++ b/src/components/SDialog.vue
@@ -3,6 +3,7 @@
     v-model="innerValue"
     v-bind="$attrs"
     :width="width"
+    :keep-content-alive="false"
     scrollable
     style="z-index:2147483640;"
     v-on="$listeners"


### PR DESCRIPTION
leaving old content is causing z-index issues, so clean up vdialogs when closed

#33024