### PR TITLE
feat(cdn): moving fonts to a new cdn

### DIFF
--- a/src/preset/typography.scss
+++ b/src/preset/typography.scss
@@ -1,8 +1,8 @@
 @font-face {
   font-family: 'proxima_nova';
-  src: url('https://stampinup-media.azureedge.net/core/fonts/proxima-nova/ProximaVara_subset.woff2') format('woff2-variations'), 
-    url('https://stampinup-media.azureedge.net/core/fonts/proxima-nova/ProximaVara_subset.woff') format('woff'),
-    url('https://stampinup-media.azureedge.net/core/fonts/proxima-nova/ProximaVara_subset.ttf') format('truetype');
+  src: url('https://sucdn.stampinup.io/media/core/fonts/proxima-nova/ProximaVara_subset.woff2') format('woff2-variations'), 
+    url('https://sucdn.stampinup.io/media/core/fonts/proxima-nova/ProximaVara_subset.woff') format('woff'),
+    url('https://sucdn.stampinup.io/media/core/fonts/proxima-nova/ProximaVara_subset.ttf') format('truetype');
   font-weight: 100 950;
   font-stretch: 50% 200%;
   font-style: normal;


### PR DESCRIPTION
fonts are no longer housed in the SU datacenter instead now housed in Azure