### PR TITLE
fix: add [skip ci] to standard-version release commits

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,0 +1,3 @@
+{
+  "releaseCommitMessageFormat": "chore(release): {{currentTag}} [skip ci]"
+}


### PR DESCRIPTION
## Summary
- Adds `.versionrc.json` to configure `standard-version` to append `[skip ci]` to its release commit messages
- Prevents the CI loop where each `chore(release):` commit re-triggered the pipeline, which ran `standard-version` again, creating another commit, ad infinitum

## Test plan
- [ ] Merge and verify the next real commit triggers the pipeline normally
- [ ] Verify the resulting `chore(release): x.y.z [skip ci]` commit does NOT re-trigger the pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)